### PR TITLE
fix(variables): update IAM role ARNs to correct account

### DIFF
--- a/modules/eks_instance/variables.tf
+++ b/modules/eks_instance/variables.tf
@@ -7,7 +7,7 @@ variable "project_name" {
 }
 
 variable "lab_role" {
-  default = "arn:aws:iam::618427392221:role/LabRole"
+  default = "arn:aws:iam::905417995957:role/LabRole"
 }
 
 variable "access_config" {
@@ -23,7 +23,7 @@ variable "instance_type" {
 }
 
 variable "principal_arn" {
-  default = "arn:aws:iam::618427392221:role/voclabs"
+  default = "arn:aws:iam::905417995957:role/voclabs"
 }
 
 variable "policy_arn" {


### PR DESCRIPTION
This pull request updates the default AWS IAM role ARNs in the `modules/eks_instance/variables.tf` file to use a different AWS account. These changes ensure that resources are created with the correct roles for the intended AWS environment.

Role ARN updates:

* Changed the default value of the `lab_role` variable to use the role from AWS account `905417995957` instead of `618427392221`.
* Changed the default value of the `principal_arn` variable to use the role from AWS account `905417995957` instead of `618427392221`.