### PR TITLE
Refactor: remove unused IAM role and variable for voclabs

### DIFF
--- a/modules/eks_instance/data.tf
+++ b/modules/eks_instance/data.tf
@@ -2,10 +2,6 @@ data "aws_iam_role" "fiap_lab_role" {
   name = "LabRole"
 }
 
-data "aws_iam_role" "voclabs_role" {
-  name = "voclabs"
-}
-
 data "aws_eks_cluster" "eks_cluster" {
   name       = var.project_name
   depends_on = [aws_eks_cluster.eks-cluster]

--- a/modules/eks_instance/outputs.tf
+++ b/modules/eks_instance/outputs.tf
@@ -34,10 +34,6 @@ output "lab_role_arn" {
   value = data.aws_iam_role.fiap_lab_role.arn
 }
 
-output "principal_arn" {
-  value = data.aws_iam_role.voclabs_role.arn
-}
-
 output "cluster_ca_certificate" {
   value = aws_eks_cluster.eks-cluster.certificate_authority[0].data
 }

--- a/modules/eks_instance/variables.tf
+++ b/modules/eks_instance/variables.tf
@@ -24,12 +24,6 @@ variable "instance_type" {
   default = "t3.medium"
 }
 
-variable "principal_arn" {
-  description = "Principal ARN retrieved dynamically from AWS"
-  type        = string
-  default     = null
-}
-
 variable "policy_arn" {
   default = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
 }


### PR DESCRIPTION
This pull request removes support for the `voclabs_role` IAM role and its associated outputs and variables from the `eks_instance` module. The changes simplify the module by eliminating unused configuration related to the `principal_arn`.

**IAM Role and Output Cleanup:**

* Removed the `data "aws_iam_role" "voclabs_role"` data source from `data.tf`, which previously retrieved the `voclabs` IAM role.
* Removed the `output "principal_arn"` from `outputs.tf`, which previously exposed the ARN of the `voclabs_role`.

**Variable Cleanup:**

* Removed the `variable "principal_arn"` from `variables.tf`, which was used to pass the principal ARN dynamically.