### PR TITLE
fix(parameter_group): correct Redis version in parameter group family

### DIFF
--- a/modules/elasticache_instance/main.tf
+++ b/modules/elasticache_instance/main.tf
@@ -10,7 +10,7 @@ resource "aws_elasticache_subnet_group" "main" {
 
 resource "aws_elasticache_parameter_group" "main" {
   count       = var.parameter_group_name == null ? 1 : 0
-  family      = var.parameter_group_family != null ? var.parameter_group_family : (var.engine == "redis" ? "redis7.x" : "memcached1.6")
+  family      = var.parameter_group_family != null ? var.parameter_group_family : (var.engine == "redis" ? "redis7.0" : "memcached1.6")
   name        = "${var.project_name}-${var.environment}-${var.engine}-params"
   description = "Parameter group for ${var.engine} in ${var.project_name} project"
 


### PR DESCRIPTION
This pull request makes a minor update to the default parameter group family for Redis in the Elasticache module. The default family is changed from `redis7.x` to `redis7.0` for new parameter groups.

* Changed the default value of the `family` property in `aws_elasticache_parameter_group` to use `redis7.0` instead of `redis7.x` when the engine is Redis (`modules/elasticache_instance/main.tf`).