### PR TITLE
Fix: Cache parameter group family

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,19 @@ tf-init: ## Initialize Terraform
 	terraform init
 
 .PHONY: tf-plan
-tf-plan: ## Show Terraform plan
+tf-plan: ## Show Terraform plan and save to file
 	@echo  "🟢 Showing Terraform plan..."
-	terraform plan
+	terraform plan -out=tfplan
 
 .PHONY: tf-apply
-tf-apply: ## Apply Terraform
+tf-apply: ## Apply Terraform from saved plan
 	@echo  "🟢 Applying Terraform..."
-	terraform apply -auto-approve
+	terraform apply -input=false -auto-approve tfplan
+
+.PHONY: tf-apply-direct
+tf-apply-direct: ## Apply Terraform directly (without plan file)
+	@echo  "🟢 Applying Terraform directly..."
+	terraform apply -input=false -auto-approve
 
 .PHONY: tf-destroy
 tf-destroy: ## Destroy Terraform resources

--- a/modules/elasticache_instance/main.tf
+++ b/modules/elasticache_instance/main.tf
@@ -10,7 +10,7 @@ resource "aws_elasticache_subnet_group" "main" {
 
 resource "aws_elasticache_parameter_group" "main" {
   count       = var.parameter_group_name == null ? 1 : 0
-  family      = var.parameter_group_family != null ? var.parameter_group_family : (var.engine == "redis" ? "redis7.0" : "memcached1.6")
+  family      = var.parameter_group_family != null ? var.parameter_group_family : (var.engine == "redis" ? "redis7" : "memcached1.6")
   name        = "${var.project_name}-${var.environment}-${var.engine}-params"
   description = "Parameter group for ${var.engine} in ${var.project_name} project"
 

--- a/modules/elasticache_instance/provider.tf
+++ b/modules/elasticache_instance/provider.tf
@@ -1,8 +1,1 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
+


### PR DESCRIPTION
This pull request introduces improvements to the Terraform workflow and updates to the ElastiCache module configuration. The most significant changes include enhancements to the `Makefile` for safer and more flexible Terraform operations, an update to the default Redis parameter group family, and cleanup of provider configuration.

**Terraform workflow improvements:**

* The `tf-plan` target in the `Makefile` now saves the Terraform plan to a file (`tfplan`), making it easier to review and apply changes safely.
* The `tf-apply` target now applies changes from the saved plan file, ensuring reproducible and controlled deployments. A new `tf-apply-direct` target has been added for direct application without a plan file, offering flexibility for advanced users.

**ElastiCache module updates:**

* The default Redis parameter group family in `modules/elasticache_instance/main.tf` has been updated from `redis7.0` to `redis7`, aligning with current AWS naming conventions and preventing potential misconfigurations.

**Provider configuration cleanup:**

* The redundant provider block in `modules/elasticache_instance/provider.tf` has been removed, likely to simplify configuration and avoid conflicts with root-level provider definitions.