### PR TITLE
Fix: add S3 bucket notification dependency and outputs for SQS policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+tfplan

--- a/modules/s3_instance/main.tf
+++ b/modules/s3_instance/main.tf
@@ -7,7 +7,8 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket   = aws_s3_bucket.bucket.id
+  bucket     = aws_s3_bucket.bucket.id
+  depends_on = [aws_s3_bucket.bucket, var.sqs_queue_policy_dependency]
 
   queue {
     queue_arn = var.sqs_queue_arn

--- a/modules/s3_instance/main.tf
+++ b/modules/s3_instance/main.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "bucket" {
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket     = aws_s3_bucket.bucket.id
-  depends_on = [aws_s3_bucket.bucket, var.sqs_queue_policy_dependency]
+  depends_on = [var.sqs_queue_policy_dependency]
 
   queue {
     queue_arn = var.sqs_queue_arn

--- a/modules/s3_instance/variables.tf
+++ b/modules/s3_instance/variables.tf
@@ -12,12 +12,18 @@ variable "environment" {
 
 variable "s3_bucket_name" {
   description = "Name of the S3 bucket that will send messages to the SQS queues"
-  type = string
+  type        = string
 }
 
 variable "sqs_queue_arn" {
   description = "ARN of the SQS queue that will receive messages from the S3 buckets"
   type        = string
+}
+
+variable "sqs_queue_policy_dependency" {
+  description = "Dependency variable to ensure SQS queue policies are created before S3 notification"
+  type        = any
+  default     = null
 }
 
 variable "common_tags" {

--- a/modules/sqs_instance/outputs.tf
+++ b/modules/sqs_instance/outputs.tf
@@ -13,3 +13,11 @@ output "sqs_queue_arns" {
     key => queue.arn
   }
 }
+
+output "s3_to_sqs_policies" {
+  description = "Map of S3-to-SQS policies for dependency management"
+  value = {
+    for key, policy in aws_sqs_queue_policy.s3_to_sqs :
+    key => policy.id
+  }
+}


### PR DESCRIPTION
This pull request improves the reliability of S3 event notifications sent to SQS queues by ensuring that SQS queue policies are created before S3 bucket notifications are configured. It introduces new dependency management between modules and updates resource definitions to prevent race conditions during infrastructure provisioning.

**Dependency management improvements:**

* Added a new `sqs_queue_policy_dependency` variable to the `s3_instance` module, allowing explicit dependency on SQS queue policies for S3 notifications. (`modules/s3_instance/variables.tf` [modules/s3_instance/variables.tfR23-R28](diffhunk://#diff-8c1939140af4f1183b3cef1b0bbb9b5d7b736adf77303236f2b85837644235ffR23-R28))
* Updated the `aws_s3_bucket_notification` resource to depend on both the S3 bucket and the SQS queue policy, ensuring proper creation order. (`modules/s3_instance/main.tf` [modules/s3_instance/main.tfR11](diffhunk://#diff-153aa6eff2c32fa1cb53ca057a7a54787d5e65baa359618806df80baa751a111R11))
* Modified the `main.tf` root module to pass the new `sqs_queue_policy_dependency` from the `sqs_instance` module to the `s3_instance` module. (`main.tf` [main.tfR122](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR122))

**Outputs and data flow enhancements:**

* Added an output `s3_to_sqs_policies` to the `sqs_instance` module to expose SQS policy IDs for dependency management. (`modules/sqs_instance/outputs.tf` [modules/sqs_instance/outputs.tfR16-R23](diffhunk://#diff-74b493e266e387a3443666618d7ded0a8a7d490e2e6717d08bc07cbbc007ca50R16-R23))

**Configuration improvements:**

* Updated the transformation logic for SQS queues to include S3 bucket ARNs for specific queues, improving event routing configuration. (`main.tf` [main.tfL94-R99](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL94-R99))