### PR TITLE
Feature: update SQS queue name to video-status-updated and adjust SNS…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,7 @@ locals {
   transformed_sqs_queues = {
     for key, value in var.sqs_queues :
     key => merge(value,
-      key == "video-status-notification.fifo" ? {
+      key == "video-status-updated.fifo" ? {
         sns_topic_arn = module.sns_instance.sns_topic_arns["video-status-updated"],
       } : {},
       key == "video-uploaded" ? {

--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "sqs_queues" {
       }
     }
     "notification" = {
-      name                        = "video-status-notification.fifo"
+      name                        = "video-status-updated.fifo"
       delay_seconds               = 0
       message_retention_seconds   = 1209600 # 14 days
       visibility_timeout_seconds  = 60
@@ -131,7 +131,7 @@ variable "sns_topics" {
   default = {
     "video-status-updated" = {
       name = "video-status-updated"
-      tags = { 
+      tags = {
         Purpose = "Sends a notification to users when a video has its status updated"
       }
     }
@@ -140,6 +140,6 @@ variable "sns_topics" {
 
 variable "s3_bucket_video_processor_raw_videos" {
   description = "Map of S3 bucket configurations"
-  type = string
-  default = "fiapx-10soat-g21"
+  type        = string
+  default     = "fiapx-10soat-g21"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "sqs_queues" {
         Purpose = "Receives an event from S3 when a video is uploaded"
       }
     }
-    "notification" = {
+    "video-status-updated" = {
       name                        = "video-status-updated.fifo"
       delay_seconds               = 0
       message_retention_seconds   = 1209600 # 14 days
@@ -116,7 +116,7 @@ variable "sqs_queues" {
       fifo_queue                  = true
       content_based_deduplication = true
       tags = {
-        Purpose = "Receives an event from SNS when a video has its status updated and sends a notification to users"
+        Purpose = "Receives an event from SNS when a video has its status updated"
       }
     }
   }
@@ -132,7 +132,7 @@ variable "sns_topics" {
     "video-status-updated" = {
       name = "video-status-updated"
       tags = {
-        Purpose = "Sends a notification to users when a video has its status updated"
+        Purpose = "Notifies when a video's status is updated"
       }
     }
   }


### PR DESCRIPTION
This pull request updates the naming and configuration for one of the SQS queues related to video status notifications. The primary change is a renaming to ensure consistency between queue and topic names.

**SQS queue and SNS topic naming alignment:**

* Renamed the SQS queue from `video-status-notification.fifo` to `video-status-updated.fifo` in the `sqs_queues` variable definition in `variables.tf` to match the corresponding SNS topic.
* Updated the logic in the `main.tf` locals block to reference `video-status-updated.fifo` instead of `video-status-notification.fifo` when assigning the `sns_topic_arn`.… topic tags