### PR TITLE
Remove unused AWS_REGION variable from environment settings

### DIFF
--- a/modules/lambda_user_service/main.tf
+++ b/modules/lambda_user_service/main.tf
@@ -26,7 +26,6 @@ resource "aws_lambda_function" "user_service" {
     variables = merge(var.environment_variables, {
       USERS_TABLE_NAME = var.users_table_name
       IDS_TABLE_NAME   = var.ids_table_name
-      AWS_REGION       = var.aws_region
       # Parameter Store extension configuration
       PARAMETERS_SECRETS_EXTENSION_LOG_LEVEL = "info"
       PARAMETERS_SECRETS_EXTENSION_CACHE_ENABLED = "true"


### PR DESCRIPTION
Removed the AWS_REGION variable from the environment settings in the `lambda_user_service` as it was no longer in use. This reduces unnecessary configuration and improves maintainability.