### PR TITLE
Add aws_account_id variable and refactor Lambda image URIs

### DIFF
--- a/.github/workflows/cd-create-aws-tf.yaml
+++ b/.github/workflows/cd-create-aws-tf.yaml
@@ -28,6 +28,11 @@ jobs:
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ env.REGION_DEFAULT }}
 
+      - name: Get AWS Account ID
+        run: |
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID" >> $GITHUB_ENV
+
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v3
 
@@ -47,6 +52,7 @@ jobs:
       - name: Terraform Plan
         id: plan
         env:
+          TF_VAR_aws_account_id: ${{ env.AWS_ACCOUNT_ID }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_rds_db_password: ${{ secrets.RDS_DB_PASSWORD }}
           TF_VAR_rds_db_username: ${{ secrets.RDS_DB_USERNAME }}

--- a/.github/workflows/cd-create-aws-tf.yaml
+++ b/.github/workflows/cd-create-aws-tf.yaml
@@ -56,6 +56,7 @@ jobs:
       - name: Terraform Apply
         id: apply
         env:
+          TF_VAR_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
           TF_VAR_rds_db_password: ${{ secrets.RDS_DB_PASSWORD }}
           TF_VAR_rds_db_username: ${{ secrets.RDS_DB_USERNAME }}

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ module "lambda_user_service" {
 
   project_name                  = var.project_name
   environment                   = var.environment
-  lambda_image_uri              = var.lambda_user_service_image_uri
+  lambda_image_uri              = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/user_lambda:latest"
   lambda_memory                 = var.lambda_user_service_memory
   lambda_timeout                = var.lambda_user_service_timeout
   users_table_name              = module.dynamodb_instance.users_table_name
@@ -184,7 +184,7 @@ module "lambda_job_starter" {
 
   project_name     = var.project_name
   environment      = var.environment
-  lambda_image_uri = var.lambda_image_uri
+  lambda_image_uri = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/hackathon-lambda-job-starter:latest"
   lambda_memory    = var.lambda_memory
   lambda_timeout   = var.lambda_timeout
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,11 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "aws_account_id" {
+  description = "AWS Account ID"
+  type        = string
+}
+
 variable "common_tags" {
   description = "Common tags to apply to all resources"
   type        = map(string)
@@ -68,7 +73,6 @@ variable "elasticache_port" {
 variable "lambda_image_uri" {
   description = "URI of the Lambda container image"
   type        = string
-  default     = "905417995957.dkr.ecr.us-east-1.amazonaws.com/hackathon-lambda-job-starter:latest"
 }
 
 variable "lambda_memory" {


### PR DESCRIPTION
### Overview
This pull request introduces the `aws_account_id` variable to the Terraform configurations and refactors Lambda image URIs to utilize this variable dynamically.

### Changes
- Added `aws_account_id` variable to Terraform.
- Replaced hardcoded Lambda image URIs with dynamic URIs using `aws_account_id`.
- Removed the hardcoded default value for `lambda_image_uri`.
- Updated GitHub Actions workflows to pass `aws_account_id` as an environment variable.

### Checklist
- [ ] Tests updated or added to cover the changes.
- [ ] Documentation updated where necessary.