### PR TITLE
feat(terraform): update S3 bucket name for Terraform state

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The infrastructure supports different environments through variables:
 ### Backend Configuration
 
 The Terraform state is stored in an S3 backend:
-- **Bucket**: `video-terraform-state-soat-g21-hackathon`
+- **Bucket**: `tf-state-10soat-g21-hackathon`
 - **Key**: `terraform.tfstate`
 - **Region**: `us-east-1`
 

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket = "video-terraform-state-soat-g21-hackathon"
+    bucket = "tf-state-10soat-g21-hackathon"
     key    = "terraform.tfstate"
     region = "us-east-1"
   }


### PR DESCRIPTION
This pull request updates the S3 bucket name used for storing the Terraform state to reflect a new naming convention. The change ensures both the documentation and the Terraform configuration are consistent.

Infrastructure configuration:

* Updated the S3 backend bucket name in `main.tf` from `video-terraform-state-soat-g21-hackathon` to `tf-state-10soat-g21-hackathon` for storing the Terraform state.

Documentation:

* Updated the bucket name reference in the backend configuration section of `README.md` to match the new S3 bucket name.