### PR TITLE
refactor(variables): remove unused Lambda image URI variables

### DIFF
--- a/.github/workflows/ci-validate.yaml
+++ b/.github/workflows/ci-validate.yaml
@@ -1,0 +1,48 @@
+name: ci/validate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGION_DEFAULT: us-east-1
+
+jobs:
+  create_infra:
+    name: CD - Create AWS Infra with Terraform
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: ${{ env.REGION_DEFAULT }}
+
+      - name: Get AWS Account ID
+        run: |
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID" >> $GITHUB_ENV
+
+      - name: Terraform Setup
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init -input=false
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color

--- a/.github/workflows/ci-validate.yaml
+++ b/.github/workflows/ci-validate.yaml
@@ -10,8 +10,8 @@ env:
   REGION_DEFAULT: us-east-1
 
 jobs:
-  create_infra:
-    name: CD - Create AWS Infra with Terraform
+  terraform_validate:
+    name: terraform validate
     runs-on: ubuntu-latest
 
     steps:

--- a/variables.tf
+++ b/variables.tf
@@ -70,10 +70,6 @@ variable "elasticache_port" {
   type        = number
   default     = 6379
 }
-variable "lambda_image_uri" {
-  description = "URI of the Lambda container image"
-  type        = string
-}
 
 variable "lambda_memory" {
   description = "Lambda memory in MB"
@@ -146,13 +142,6 @@ variable "s3_bucket_video_processor_raw_videos" {
   description = "Map of S3 bucket configurations"
   type = string
   default = "fiapx-10soat-g21"
-}
-
-# User Service Lambda Variables
-variable "lambda_user_service_image_uri" {
-  description = "URI of the User Service Lambda container image"
-  type        = string
-  default     = "905417995957.dkr.ecr.us-east-1.amazonaws.com/hackathon-user-lambda:latest"
 }
 
 variable "lambda_user_service_memory" {


### PR DESCRIPTION
This pull request makes minor cleanups to the Terraform variable definitions by removing unused Lambda image URI variables. These changes help keep the configuration lean and focused on currently used resources. No functional changes are introduced.