### PR TITLE
Fix: Lambda job starter ECR url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tf-plan: ## Show Terraform plan and save to file
 tf-apply: ## Apply Terraform from saved plan
 	@echo  "🟢 Applying Terraform..."
 	@echo "Using AWS Account ID: $(AWS_ACCOUNT_ID)"
-	@terraform apply -var "aws_account_id=$(AWS_ACCOUNT_ID)" -input=false -auto-approve tfplan
+	@terraform apply -input=false -auto-approve tfplan
 
 .PHONY: tf-apply-direct
 tf-apply-direct: ## Apply Terraform directly (without plan file)

--- a/Makefile
+++ b/Makefile
@@ -11,39 +11,39 @@ help: ## Print this message
 .PHONY: tf-init
 tf-init: ## Initialize Terraform
 	@echo  "🟢 Initializing Terraform..."
-	terraform init
+	@terraform init
 
 .PHONY: tf-validate
 tf-validate: ## Validate Terraform configuration
 	@echo  "🟢 Validating Terraform configuration..."
-	terraform validate
+	@terraform validate
 
 .PHONY: tf-plan
 tf-plan: ## Show Terraform plan and save to file
 	@echo  "🟢 Showing Terraform plan..."
 	@echo "Using AWS Account ID: $(AWS_ACCOUNT_ID)"
-	terraform plan -out=tfplan -var "aws_account_id=$(AWS_ACCOUNT_ID)"
+	@terraform plan -out=tfplan -var "aws_account_id=$(AWS_ACCOUNT_ID)"
 
 .PHONY: tf-apply
 tf-apply: ## Apply Terraform from saved plan
 	@echo  "🟢 Applying Terraform..."
 	@echo "Using AWS Account ID: $(AWS_ACCOUNT_ID)"
-	terraform apply -input=false -auto-approve tfplan -var "aws_account_id=$(AWS_ACCOUNT_ID)"
+	@terraform apply -var "aws_account_id=$(AWS_ACCOUNT_ID)" -input=false -auto-approve tfplan
 
 .PHONY: tf-apply-direct
 tf-apply-direct: ## Apply Terraform directly (without plan file)
 	@echo  "🟢 Applying Terraform directly..."
 	@echo "Using AWS Account ID: $(AWS_ACCOUNT_ID)"
-	terraform apply -input=false -auto-approve -var "aws_account_id=$(AWS_ACCOUNT_ID)"
+	@terraform apply -var "aws_account_id=$(AWS_ACCOUNT_ID)" -input=false -auto-approve
 
 .PHONY: tf-destroy
 tf-destroy: ## Destroy Terraform resources
 	@echo  "🔴 Destroying Terraform resources..."
 	@echo "Using AWS Account ID: $(AWS_ACCOUNT_ID)"
-	terraform destroy -auto-approve -var "aws_account_id=$(AWS_ACCOUNT_ID)"
+	@terraform destroy -var "aws_account_id=$(AWS_ACCOUNT_ID)" -auto-approve
 
 
 .PHONY: aws-eks-auth
 aws-eks-auth: ## Update kubeconfig for the newly created EKS cluster
 	@echo  "🟢 Updating kubeconfig for the EKS cluster..."
-	aws eks update-kubeconfig --name $(AWS_EKS_CLUSTER_NAME)
+	@aws eks update-kubeconfig --name $(AWS_EKS_CLUSTER_NAME)

--- a/main.tf
+++ b/main.tf
@@ -184,7 +184,7 @@ module "lambda_job_starter" {
 
   project_name     = var.project_name
   environment      = var.environment
-  lambda_image_uri = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/hackathon-lambda-job-starter:latest"
+  lambda_image_uri = "${var.aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/fiap-soat-g20/hackathon-job-starter-lambda:latest"
   lambda_memory    = var.lambda_memory
   lambda_timeout   = var.lambda_timeout
   queue_arn        = module.sqs_instance.sqs_queue_arns["video-uploaded"]


### PR DESCRIPTION
This pull request includes improvements to the `Makefile` for better command output handling and updates the Lambda image URI in the Terraform configuration to use the correct repository and image name. These changes enhance consistency and ensure the correct resources are referenced in your infrastructure setup.

**Makefile improvements:**

* Added `@` before all command invocations in the `Makefile` to suppress command echoing and provide cleaner output when running Terraform and AWS commands.

**Terraform configuration update:**

* Updated the `lambda_image_uri` in the `main.tf` Terraform module to point to the correct ECR repository and image name (`fiap-soat-g20/hackathon-job-starter-lambda:latest`) instead of the previous path.